### PR TITLE
Bugfix post display

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -72,20 +72,13 @@ class Block {
 			<h2>Post Counts</h2>
 			<ul>
 			<?php
-			foreach ( $post_types as $post_type_slug ) :
-                $post_type_object = get_post_type_object( $post_type_slug  );
-                $post_count = count(
-                    get_posts(
-						[
-							'post_type' => $post_type_slug,
-							'posts_per_page' => -1,
-						]
-					)
-                );
-
-				?>
-				<li><?php echo 'There are ' . $post_count . ' ' .
-					  $post_type_object->labels->name . '.'; ?></li>
+				foreach ( $post_types as $post_type_slug ) :
+					$post_type_object = get_post_type_object( $post_type_slug );
+					$post_count       = ( 'attachment' !== $post_type_slug ) ? wp_count_posts( $post_type_slug )->publish : array_sum( (array) wp_count_attachments() );
+					?>
+					<li>
+						<?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name; ?> 
+					</li> 
 			<?php endforeach;	?>
 			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -80,7 +80,7 @@ class Block {
 						<?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name; ?> 
 					</li> 
 			<?php endforeach;	?>
-			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
+			<p><?php echo 'The current post ID is ' . get_the_ID(); //or can be used with sanitize_text_field(GET['post_id'])?></p>
 
 			<?php
 			$query = new WP_Query(  array(

--- a/php/Block.php
+++ b/php/Block.php
@@ -40,6 +40,7 @@ class Block {
 	 */
 	public function init() {
 		add_action( 'init', [ $this, 'register_block' ] );
+		add_action( 'save_post', [ $this, 'xwp_set_custom_post_cache' ], 10, 3 );
 	}
 
 	/**
@@ -55,6 +56,18 @@ class Block {
 	}
 
 	/**
+	 * Set object cache for custom post loop
+	 *
+	 * @param int     $post_id post id.
+	 * @param object  $post post object.
+	 * @param boolean $update post update flag.
+	 * @return void
+	 */
+	function xwp_set_custom_post_cache( $post_id, $post, $update ) {
+		$this->xwp_get_top_posts_cat_foo_baz( true );
+	}
+
+	/**
 	 * Renders the block.
 	 *
 	 * @param array    $attributes The attributes for the block.
@@ -63,15 +76,15 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		$post_types = get_post_types(  [ 'public' => true ] );
+		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
 		ob_start();
-
 		?>
-        <div class="<?php echo $class_name; ?>">
+		<div class="<?php echo $class_name; ?>">
 			<h2>Post Counts</h2>
 			<ul>
-			<?php
+				<?php get_posts(); ?>
+				<?php
 				foreach ( $post_types as $post_type_slug ) :
 					$post_type_object = get_post_type_object( $post_type_slug );
 					$post_count       = ( 'attachment' !== $post_type_slug ) ? wp_count_posts( $post_type_slug )->publish : array_sum( (array) wp_count_attachments() );
@@ -79,43 +92,73 @@ class Block {
 					<li>
 						<?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name; ?> 
 					</li> 
-			<?php endforeach;	?>
-			<p><?php echo 'The current post ID is ' . get_the_ID(); //or can be used with sanitize_text_field(GET['post_id'])?></p>
-
-			<?php
-			$query = new WP_Query(  array(
-				'post_type' => ['post', 'page'],
-				'post_status' => 'any',
-				'date_query' => array(
-					array(
-						'hour'      => 9,
-						'compare'   => '>=',
-					),
-					array(
-						'hour' => 17,
-						'compare'=> '<=',
-					),
-				),
-                'tag'  => 'foo',
-                'category_name'  => 'baz',
-				  'post__not_in' => [ get_the_ID() ],
-			));
-
-			if ( $query->found_posts ) :
-				?>
-				 <h2>5 posts with the tag of foo and the category of baz</h2>
-                <ul>
-                <?php
-
-                 foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-                    ?><li><?php echo $post->post_title ?></li><?php
-				endforeach;
-			endif;
-		 	?>
+				<?php endforeach; ?>
 			</ul>
+			<p><?php echo 'The current post ID is ' . get_the_ID() . '.', 'site-counts'; //or can be used with sanitize_text_field(GET['post_id'])?></p>
+			<?php
+			$xwp_top_posts = $this->xwp_get_top_posts_cat_foo_baz();
+			if ( $xwp_top_posts->found_posts ) :
+				?>
+				<h2><?php _e( '5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
+				<ul>
+					<?php
+					foreach ( array_slice( $xwp_top_posts->posts, 0, 5 ) as $post ) :
+						if ( get_the_ID() === $post->ID ) {
+							continue;
+						}
+						?>
+					<li><?php echo $post->post_title; ?></li>
+						<?php
+					endforeach;
+			endif;
+			?>
+				</ul>
 		</div>
 		<?php
-
 		return ob_get_clean();
 	}
+
+	/**
+	 * Retrieve top 5 posts with tag of foo.
+	 *
+	 * @param bool $force_refresh Optional. Whether to force the cache to be refreshed. Default false.
+	 * @return array|WP_Error Array of WP_Post objects with the highest comment counts, WP_Error object otherwise.
+	 */
+	public function xwp_get_top_posts_cat_foo_baz( $force_refresh = false ) {
+		// Check for the top post from key in the 'top_posts' group.
+		$cat_foo_baz_posts = wp_cache_get( 'xwp_top_commented_posts', 'top_posts' );
+		// If nothing is found, build the object.
+		if ( true === $force_refresh || false === $cat_foo_baz_posts ) {
+			// Grab the top 10 most commented posts.
+
+			$cat_foo_baz_posts_query = new WP_Query(
+				[
+					'post_type'      => 'post',
+					'posts_per_page' => 10,
+					'no_found_rows'  => true,
+					'date_query'     => [
+						[
+							'hour'    => 9,
+							'compare' => '>=',
+						],
+						[
+							'hour'    => 17,
+							'compare' => '<=',
+						],
+					],
+					'tag'            => 'foo',
+					'category_name'  => 'baz',
+				]
+			);
+
+			$cat_foo_baz_posts = new WP_Query( $cat_foo_baz_posts_query );
+
+			if ( ! is_wp_error( $cat_foo_baz_posts ) && $cat_foo_baz_posts->have_posts() ) {
+				// In this case we don't need a timed cache expiration.
+				wp_cache_set( 'xwp_top_posts_cat_foo_baz', $cat_foo_baz_posts->posts, 'top_posts' );
+			}
+		}
+		return $cat_foo_baz_posts;
+	}
 }
+?>

--- a/php/Block.php
+++ b/php/Block.php
@@ -94,7 +94,7 @@ class Block {
 					</li> 
 				<?php endforeach; ?>
 			</ul>
-			<p><?php echo 'The current post ID is ' . get_the_ID() . '.', 'site-counts'; //or can be used with sanitize_text_field(GET['post_id'])?></p>
+			<p><?php echo 'The current post ID is ' . get_the_ID(); // or can be used with sanitize_text_field(GET['post_id']). ?></p>
 			<?php
 			$xwp_top_posts = $this->xwp_get_top_posts_cat_foo_baz();
 			if ( $xwp_top_posts->found_posts ) :


### PR DESCRIPTION

FIXED: 
 Update the code to improve post count logic avoiding extra wp_query. 
 Update to use wp function to fetch the current post id
 
 ADDED:
Feature: Add the cache logic to custom query to fetch and show posts of foo tags and the category of baz.

CHORE: 
Fix: remove extra text label from post count display and also fix php-lint minor issue.